### PR TITLE
ARXIVNG-2903: disable Google Scholar link injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Then, build the package using:
 
     npm run build
 
-To ease remaning of files, etc there is a small shell script which will pull
+To ease renaming of files, etc. there is a small shell script which will pull
 together all built deployment files. You can run it with:
 
     ./deploy-static/pack-to-deploy.sh

--- a/src/App.css
+++ b/src/App.css
@@ -381,7 +381,7 @@ h1.bib-header span {
     margin-bottom: 0.5em;
 }
 .bib-sidebar-paper > div:first-of-type {
-    margin-top: 0.5em;
+    padding-top: 0.3em;
 }
 
 .bib-sidebar-badge {

--- a/src/ui/BibMain.tsx
+++ b/src/ui/BibMain.tsx
@@ -104,7 +104,7 @@ export class BibMain extends React.Component<{state: State}, {}> {
             <React.Fragment>
                 [<a id='biboverlay_toggle' href='javascript:;' onClick={() => state.toggle()}>
                 {state.isdisabled ? `Enable ${name}` : `Disable ${name}`}</a>
-                (<a href={CONFIG.POLICY_DESCRIPTION_PAGE}>What is {name}?</a>)]
+                &nbsp;(<a href={CONFIG.POLICY_DESCRIPTION_PAGE}>What is {name}?</a>)]
             </React.Fragment>
         ) : null
 

--- a/src/ui/Outbound.tsx
+++ b/src/ui/Outbound.tsx
@@ -104,7 +104,6 @@ function SidebarReference(paper: Paper) {
 export function OutboundNoData(paper: Paper) {
     if (!paper) { return (<div></div>) }
 
-    const url = google_scholar_query(paper)
     const ref = SidebarReference(paper)
 
     return (

--- a/src/ui/Outbound.tsx
+++ b/src/ui/Outbound.tsx
@@ -30,7 +30,7 @@ const imgstyle = {height: '18px', width: 'auto'}
 const _link = (name: string, desc: string, url: string|undefined, icon: any, external: boolean = true) => {
     if (!url) {
         return null
-    } 
+    }
     return (
         <span key={name + url}>
             <a className={name} title={desc} href={url} target={external ? '_blank' : '_self'}>
@@ -63,7 +63,7 @@ const make_link = {
     cite(ref: Paper) {return _modal('cite', 'Citation entry', ref, citeIcon)},
     scholar(ref: Paper) {return _link('scholar', 'Google Scholar', google_scholar_query(ref), scholarIcon)}
 }
-    
+
 export class Outbound extends React.Component<{paper: Paper}, {}> {
     render() {
         const ref = this.props.paper
@@ -72,9 +72,9 @@ export class Outbound extends React.Component<{paper: Paper}, {}> {
         return(
             <div className = 'bib-outbound' >
                 {outbounds}
-            </div>            
+            </div>
         )
-    }   
+    }
 }
 
 export class OutboundCite extends React.Component<{paper: Paper}, {}> {
@@ -110,8 +110,6 @@ export function OutboundNoData(paper: Paper) {
     return (
       <div className='bib-outbound' style={{margin: '0.3em'}}>
         {ref}
-        <br/>
-        <a href={url} target='_blank' rel='noopener'>Google Scholar</a>
       </div>
     )
 }


### PR DESCRIPTION
This disables the Google Scholar link injection (now added by browse in https://github.com/arXiv/arxiv-browse/pull/138) and contains other very minor fixes.