### PR TITLE
ARXIVNG-3294: change page injection location for bibex to support labs-tabs

### DIFF
--- a/src/arxiv_page.ts
+++ b/src/arxiv_page.ts
@@ -159,8 +159,6 @@ function pageElement(name: string, container: string,  insertbefore: string): HT
 }
 
 export function pageElementMain(): HTMLElement {
-    // TODO
-    // return pageElement('bib-main', 'leftcolumn', 'submission-history')
     return pageElement('bib-main', 'labs-display-bib', 'labs-content-placeholder')
 }
 

--- a/src/arxiv_page.ts
+++ b/src/arxiv_page.ts
@@ -108,7 +108,7 @@ function get_current_article_url(): string {
         return ''
     }
 
-    const aid = match[0]    
+    const aid = match[0]
     if (!aid || aid.length <= 5) {
         console.log('No valid article ID extracted from the browser location.')
         return ''
@@ -154,11 +154,14 @@ function pageElement(name: string, container: string,  insertbefore: string): HT
     const elemContainer = document.getElementsByClassName(container)[0]
     const elemInsertBefore = document.getElementsByClassName(insertbefore)[0]
     elemContainer.insertBefore(main, elemInsertBefore)
+
     return main as HTMLElement
 }
 
 export function pageElementMain(): HTMLElement {
-    return pageElement('bib-main', 'leftcolumn', 'submission-history')
+    // TODO
+    // return pageElement('bib-main', 'leftcolumn', 'submission-history')
+    return pageElement('bib-main', 'labs-display-bib', 'labs-content-placeholder')
 }
 
 export function pageElementSidebar(): HTMLElement {


### PR DESCRIPTION
I built a version of bibex with the change and put it here: https://static.arxiv.org/js/bibex-dev-tabs/bibex.js

This is the same file that browse toggle-labs.js is pointing to right now:
https://github.com/arXiv/arxiv-browse/blob/b36292424dc7d3cc67d5f470b8382a121f025be7/browse/static/js/toggle-labs.js#L17